### PR TITLE
add example showing non-deterministic "sequence"

### DIFF
--- a/Example_RDF_Streams/Location_Schedule_Harris.json
+++ b/Example_RDF_Streams/Location_Schedule_Harris.json
@@ -1,0 +1,70 @@
+{
+  "@context": {
+    "@vocab": "http://www.example.org/data-vocabulary#",
+    "time": "http://www.w3.org/2006/time#",
+    "class": "http://www.example.org/class#",
+    "room": "http://www.example.org/room#",
+    "scheduledDuring": {
+      "@id": "http://www.example.org/property-vocabulary#scheduledDuring",
+      "@type": "time:Interval"
+    },
+    "hasLocation": {"@id": "http://www.example.org/property-vocabulary#hasLocation"}
+  },
+  "@graph": [
+    {
+      "@id": "_:1",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T09:00:00",
+        "time:durationDescriptionDataType": "P2H"
+      }],
+      "@graph": [{
+        "@id": "class:Mathematics_402",
+        "hasLocation": "room:Harris_1024"
+      }]
+    },
+    {
+      "@id": "_:2",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T10:00:00",
+        "time:durationDescriptionDataType": "P1H"
+      }],
+      "@graph": [{
+        "@id": "class:Physics_101",
+        "hasLocation": "room:Harris_1023"
+      }]
+    },
+    {
+      "@id": "_:3",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T11:00:00",
+        "time:durationDescriptionDataType": "P4H"
+      }],
+      "@graph": [{
+        "@id": "class:FineArt_208",
+        "hasLocation": "room:Harris_1024"
+      }]
+    },
+    {
+      "@id": "_:4",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T11:00:00",
+        "time:durationDescriptionDataType": "P2H"
+      }],
+      "@graph": [{
+        "@id": "class:English_305",
+        "hasLocation": "room:Harris_1023"
+      }]
+    },
+    {
+      "@id": "_:5",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T13:00:00",
+        "time:durationDescriptionDataType": "P2H"
+      }],
+      "@graph": [{
+        "@id": "class:ComputerScience_503",
+        "hasLocation": "room:Harris_1023"
+      }]
+    }
+  ]
+}

--- a/Example_RDF_Streams/Location_Schedule_Harris_1023.json
+++ b/Example_RDF_Streams/Location_Schedule_Harris_1023.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://www.example.org/data-vocabulary#",
+    "time": "http://www.w3.org/2006/time#",
+    "class": "http://www.example.org/class#",
+    "room": "http://www.example.org/room#",
+    "scheduledDuring": {
+      "@id": "http://www.example.org/property-vocabulary#scheduledDuring",
+      "@type": "time:Interval"
+    },
+    "hasLocation": {
+      "@id": "http://www.example.org/property-vocabulary#hasLocation",
+    }
+  },
+  "@graph": [
+    {
+      "@id": "_:1",
+      "scheduledDuring": [
+       {"time:hasBeginning": "2015-02-05T10:00:00",
+       "time:durationDescriptionDataType": "P1H"
+       }
+      ],
+      "@graph": [
+        {
+          "@id": "class:Physics_101",
+          "hasLocation": "room:Harris_1023"
+        }
+      ]
+    },
+    {
+      "@id": "_:2",
+      "scheduledDuring": [
+       {"time:hasBeginning": "2015-02-05T11:00:00",
+       "time:durationDescriptionDataType": "P2H"
+       }
+      ],
+      "@graph": [
+        {
+          "@id": "class:English_305",
+          "hasLocation": "room:Harris_1023"
+        }
+      ]
+    },
+    {
+      "@id": "_:3",
+      "scheduledDuring": [
+       {"time:hasBeginning": "2015-02-05T13:00:00",
+       "time:durationDescriptionDataType": "P2H"
+       }
+      ],
+      "@graph": [
+        {
+          "@id": "class:ComputerScience_503",
+          "hasLocation": "room:Harris_1023"
+        }
+      ]
+    }
+  ]
+}

--- a/Example_RDF_Streams/Location_Schedule_Harris_1024.json
+++ b/Example_RDF_Streams/Location_Schedule_Harris_1024.json
@@ -1,0 +1,45 @@
+{
+  "@context": {
+    "@vocab": "http://www.example.org/data-vocabulary#",
+    "time": "http://www.w3.org/2006/time#",
+    "class": "http://www.example.org/class#",
+    "room": "http://www.example.org/room#",
+    "scheduledDuring": {
+      "@id": "http://www.example.org/property-vocabulary#scheduledDuring",
+      "@type": "time:Interval"
+    },
+    "hasLocation": {
+      "@id": "http://www.example.org/property-vocabulary#hasLocation",
+    }
+  },
+  "@graph": [
+    {
+      "@id": "_:1",
+      "scheduledDuring": [
+       {"time:hasBeginning": "2015-02-05T09:00:00",
+       "time:durationDescriptionDataType": "P2H"
+       }
+      ],
+      "@graph": [
+        {
+          "@id": "class:Mathematics_402",
+          "hasLocation": "room:Harris_1024"
+        }
+      ]
+    },
+    {
+      "@id": "_:2",
+      "scheduledDuring": [
+       {"time:hasBeginning": "2015-02-05T11:00:00",
+       "time:durationDescriptionDataType": "P4H"
+       }
+      ],
+      "@graph": [
+        {
+          "@id": "class:FineArt_208",
+          "hasLocation": "room:Harris_1024"
+        }
+      ]
+    }
+  ]
+}

--- a/Example_RDF_Streams/Location_Schedule_Harris_w_rank.json
+++ b/Example_RDF_Streams/Location_Schedule_Harris_w_rank.json
@@ -1,0 +1,70 @@
+{
+  "@context": {
+    "@vocab": "http://www.example.org/data-vocabulary#",
+    "time": "http://www.w3.org/2006/time#",
+    "class": "http://www.example.org/class#",
+    "room": "http://www.example.org/room#",
+    "scheduledDuring": {
+      "@id": "http://www.example.org/property-vocabulary#scheduledDuring",
+      "@type": "time:Interval"
+    },
+    "hasLocation": {"@id": "http://www.example.org/property-vocabulary#hasLocation"}
+  },
+  "@graph": [
+    [1,{
+      "@id": "_:1",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T09:00:00",
+        "time:durationDescriptionDataType": "P2H"
+      }],
+      "@graph": [{
+        "@id": "class:Mathematics_402",
+        "hasLocation": "room:Harris_1024"
+      }]
+    }],
+    [1,{
+      "@id": "_:2",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T10:00:00",
+        "time:durationDescriptionDataType": "P1H"
+      }],
+      "@graph": [{
+        "@id": "class:Physics_101",
+        "hasLocation": "room:Harris_1023"
+      }]
+    }],
+    [3,{
+      "@id": "_:3",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T11:00:00",
+        "time:durationDescriptionDataType": "P4H"
+      }],
+      "@graph": [{
+        "@id": "class:FineArt_208",
+        "hasLocation": "room:Harris_1024"
+      }]
+    }],
+    [3,{
+      "@id": "_:4",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T11:00:00",
+        "time:durationDescriptionDataType": "P2H"
+      }],
+      "@graph": [{
+        "@id": "class:English_305",
+        "hasLocation": "room:Harris_1023"
+      }]
+    }],
+    [4,{
+      "@id": "_:5",
+      "scheduledDuring": [{
+        "time:hasBeginning": "2015-02-05T13:00:00",
+        "time:durationDescriptionDataType": "P2H"
+      }],
+      "@graph": [{
+        "@id": "class:ComputerScience_503",
+        "hasLocation": "room:Harris_1023"
+      }]
+    }]
+  ]
+}

--- a/Example_RDF_Streams/Location_Subject.json
+++ b/Example_RDF_Streams/Location_Subject.json
@@ -1,0 +1,48 @@
+{
+  "@context": {
+    "vocab": "http://www.example.org/data-vocabulary#",
+    "observedAt": {
+      "@id": "http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#observationSamplingTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "hasLocation": {
+      "@id": "http://example.org/property-vocabulary#hasLocation",
+    }
+  },
+  "@graph": [
+    {
+      "@id": "_:1",
+      "observedAt": "2015-01-01T01:00:00",
+      "@graph": [
+        {
+          "@id": "_:Subject_A",
+          "hasLocation": "X"
+        }
+      ]
+    },
+    {
+      "@id": "_:2",
+      "observedAt": "2015-01-01T01:01:00",
+      "@graph": [
+        {
+          "@id": "_:Subject_A",
+          "hasLocation": "X"
+        },
+        {
+          "@id": "_:Subject_B",
+          "hasLocation": "Y"
+        }
+      ]
+    },
+    {
+      "@id": "_:3",
+      "observedAt": "2015-01-01T01:02:00",
+      "@graph": [
+        {
+          "@id": "_:Subject_B",
+          "hasLocation": "X"
+        }
+      ]
+    }
+  ]
+}

--- a/Example_RDF_Streams/Location_Subject.json
+++ b/Example_RDF_Streams/Location_Subject.json
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "vocab": "http://www.example.org/data-vocabulary#",
+    "@vocab": "http://www.example.org/data-vocabulary#",
     "observedAt": {
       "@id": "http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#observationSamplingTime",
       "@type": "http://www.w3.org/2001/XMLSchema#dateTime"

--- a/Example_RDF_Streams/Location_TempC_Minute.json
+++ b/Example_RDF_Streams/Location_TempC_Minute.json
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "vocab": "http://www.example.org/data-vocabulary#",
+    "@vocab": "http://www.example.org/data-vocabulary#",
     "observedAt": {
       "@id": "http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#observationSamplingTime",
       "@type": "http://www.w3.org/2001/XMLSchema#dateTime"

--- a/Example_RDF_Streams/Location_TempC_Minute_MergedCities.json
+++ b/Example_RDF_Streams/Location_TempC_Minute_MergedCities.json
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "vocab": "http://www.example.org/data-vocabulary#",
+    "@vocab": "http://www.example.org/data-vocabulary#",
     "observedAt": {
       "@id": "http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#observationSamplingTime",
       "@type": "http://www.w3.org/2001/XMLSchema#dateTime"

--- a/Example_RDF_Streams/Location_TempC_Minute_MergedCities.json
+++ b/Example_RDF_Streams/Location_TempC_Minute_MergedCities.json
@@ -1,0 +1,52 @@
+{
+  "@context": {
+    "vocab": "http://www.example.org/data-vocabulary#",
+    "observedAt": {
+      "@id": "http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#observationSamplingTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "hasTemp": {
+      "@id": "http://example.org/property-vocabulary#hasPointTempC",
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "source": {"@id": "http://example.org/data-sources/"}
+  },
+  "@graph": [
+    {
+      "@id": "source:Berlin_1",
+      "observedAt": "2015-01-01T01:01:00"
+    },
+    {
+      "@id": "source:Madrid_1",
+      "observedAt": "2015-01-01T01:01:00"
+    },
+    {
+      "@id": "source:Paris_1",
+      "observedAt": "2015-01-01T01:01:00"
+    },
+    {
+      "@id": "source:Berlin_2",
+      "observedAt": "2015-01-01T01:02:00"
+    },
+    {
+      "@id": "source:Madrid_2",
+      "observedAt": "2015-01-01T01:02:00"
+    },
+    {
+      "@id": "source:Paris_2",
+      "observedAt": "2015-01-01T01:02:00"
+    },
+    {
+      "@id": "source:Berlin_3",
+      "observedAt": "2015-01-01T01:03:00"
+    },
+    {
+      "@id": "source:Madrid_3",
+      "observedAt": "2015-01-01T01:03:00"
+    },
+    {
+      "@id": "source:Paris_3",
+      "observedAt": "2015-01-01T01:03:00"
+    }
+  ]
+}

--- a/Example_RDF_Streams/Location_TempC_Minute_MergedCities_w_rank.json
+++ b/Example_RDF_Streams/Location_TempC_Minute_MergedCities_w_rank.json
@@ -1,0 +1,52 @@
+{
+  "@context": {
+    "@vocab": "http://www.example.org/data-vocabulary#",
+    "observedAt": {
+      "@id": "http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#observationSamplingTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "hasTemp": {
+      "@id": "http://example.org/property-vocabulary#hasPointTempC",
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "source": {"@id": "http://example.org/data-sources/"}
+  },
+  "@graph": [
+    [3, {
+      "@id": "source:Berlin_1",
+      "observedAt": "2015-01-01T01:01:00"
+    }],
+    [3, {
+      "@id": "source:Madrid_1",
+      "observedAt": "2015-01-01T01:01:00"
+    }],
+    [3, {
+      "@id": "source:Paris_1",
+      "observedAt": "2015-01-01T01:01:00"
+    }],
+    [6, {
+      "@id": "source:Berlin_2",
+      "observedAt": "2015-01-01T01:02:00"
+    }],
+    [6, {
+      "@id": "source:Madrid_2",
+      "observedAt": "2015-01-01T01:02:00"
+    }],
+    [6, {
+      "@id": "source:Paris_2",
+      "observedAt": "2015-01-01T01:02:00"
+    }],
+    [9, {
+      "@id": "source:Berlin_3",
+      "observedAt": "2015-01-01T01:03:00"
+    }],
+    [9, {
+      "@id": "source:Madrid_3",
+      "observedAt": "2015-01-01T01:03:00"
+    }],
+    [9, {
+      "@id": "source:Paris_3",
+      "observedAt": "2015-01-01T01:03:00"
+    }]
+  ]
+}

--- a/Example_RDF_Streams/Location_TempC_Minute_MergedCitiesb.json
+++ b/Example_RDF_Streams/Location_TempC_Minute_MergedCitiesb.json
@@ -1,0 +1,52 @@
+{
+  "@context": {
+    "@vocab": "http://www.example.org/data-vocabulary#",
+    "observedAt": {
+      "@id": "http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#observationSamplingTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "hasTemp": {
+      "@id": "http://example.org/property-vocabulary#hasPointTempC",
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "source": {"@id": "http://example.org/data-sources/"}
+  },
+  "@graph": [
+    {
+      "@id": "source:Madrid_1",
+      "observedAt": "2015-01-01T01:01:00"
+    },
+    {
+      "@id": "source:Berlin_1",
+      "observedAt": "2015-01-01T01:01:00"
+    },
+    {
+      "@id": "source:Paris_1",
+      "observedAt": "2015-01-01T01:01:00"
+    },
+    {
+      "@id": "source:Paris_2",
+      "observedAt": "2015-01-01T01:02:00"
+    },
+    {
+      "@id": "source:Berlin_2",
+      "observedAt": "2015-01-01T01:02:00"
+    },
+    {
+      "@id": "source:Madrid_2",
+      "observedAt": "2015-01-01T01:02:00"
+    },
+    {
+      "@id": "source:Berlin_3",
+      "observedAt": "2015-01-01T01:03:00"
+    },
+    {
+      "@id": "source:Madrid_3",
+      "observedAt": "2015-01-01T01:03:00"
+    },
+    {
+      "@id": "source:Paris_3",
+      "observedAt": "2015-01-01T01:03:00"
+    }
+  ]
+}


### PR DESCRIPTION
Per request, I have added an explicit example (Location_TempC_Minute_MergedCities.json), corresponding to the usecase of a syntactic merger of three streams of temperature data at particular locations to create one stream.

The original streams are in the form where the name of the graph is an IRI, and the graph is not included explicitly in the stream.

The merged stream simply combines the stream elements of the original streams, without change.

The observation times coincide, and so a sequence ordering of the timestamp triples cannot be uniquely determined.

If merger required creating a new timestamped graph combining all observations at a given time, then this would require dereferencing the graph names, and I don't think this would be an acceptable alternative.