### PR TITLE
Revised section heading

### DIFF
--- a/RSP_Requirements_Design_Document/index.html
+++ b/RSP_Requirements_Design_Document/index.html
@@ -663,7 +663,7 @@ WHERE {
            </code></pre>
          </section>
          <section>  
-         <h4>Aggregations</h4>
+         <h4>Non-blocking Aggregation Operators</h4>
           <p>Some aggregation functions can also be applied directly over the stream without the need for an S2S operation, e.g., 
              MAX, MIN, SUM.
           </p>


### PR DESCRIPTION
Having the heading "aggregation" under streaming operators is confusing. Not all aggregations are covered here. I suggest that we change the heading to "Non-blocking Aggregation Operators" to make it clear that we are considering the specific set of operators that can be applied over a stream.

An issue that may arise is if the processing of a query does not start at the same time as the stream. The result of such a query could be wrong. The answer to such a query should include meta information about when the processing was commenced.
