### PR TITLE
Added word for clarity

### DIFF
--- a/RSP_Requirements_Design_Document/index.html
+++ b/RSP_Requirements_Design_Document/index.html
@@ -581,7 +581,7 @@ FROM NAMED :people
         <ul>
           <li><b>S2R:</b> Stream to bounded RDF, which inherits the idea of stream-to-relation 
               operators in CQL which produce a relation from a stream.</li>
-          <li><b>R2R:</b> Bounded RDF to RDF, which inherits the idea of relation-to-relation 
+          <li><b>R2R:</b> Bounded RDF to bounded RDF, which inherits the idea of relation-to-relation 
               operators in CQL which produce a relation from one or more other relations.</li>
           <li><b>R2S:</b> Bounded RDF to Stream, which inherits the idea of relation-to-stream 
               operators in CQL which produce a stream from a relation.</li>


### PR DESCRIPTION
For clarity it would be better to explicitly state that R2R is bounded RDF to bounded RDF.
